### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ for viewing on actual old-school CGA screens... for that, I'd need
 to adjust for the aspect ratio of rectangular 80's pixels versus the 
 square pixels of today.
 
-## Get 
+## Installation
 
-    go get github.com/rwtodd/Go.Cgaify/cmd/cgaify
+    go install github.com/rwtodd/Go.Cgaify/cmd/cgaify@latest
 
 Giving `-h` will give usage information.
 

--- a/README.md
+++ b/README.md
@@ -42,3 +42,9 @@ square pixels of today.
 
 Giving `-h` will give usage information.
 
+### Installation: step by step
+- install go(lang) https://go.dev/doc/install
+- install cgaify (`go install github.com/rwtodd/Go.Cgaify/cmd/cgaify@latest`)
+- go to `$GOPATH/bin` where cgaify is installed (you can check `GOPATH` value by doing `go env`)
+- run `./cgaify -h` to see options. `./cgaify -m CGA1 $PATH_TO_REPO/example/example.jpg`
+- Image `example.jpg_CGA1.gif` will be generated in this directory


### PR DESCRIPTION
- I updated `go get` url because I got this (error?) message.
```
go: go.mod file not found in current directory or any parent directory.
    'go get' is no longer supported outside a module.
    To build and install a command, use 'go install' with a version,
    like 'go install example.com/cmd@latest'
    For more information, see https://golang.org/doc/go-get-install-deprecation
    or run 'go help get' or 'go help install'.
```
- I added "step by step instructions", since I am not familiar with go, and had to google around a bit to make this work.

*PS:* cool project!